### PR TITLE
126 bug fix in create access token form

### DIFF
--- a/src/pages/AccessTokenDetails.js
+++ b/src/pages/AccessTokenDetails.js
@@ -64,6 +64,7 @@ const AccessTokenDetails = () => {
 
   // Token states
   const [accessKeyId, setAccessKeyId] = useState(null);
+  const MAX_TOKEN_NAME_LENGTH = 30;
   const [tokenName, setTokenName] = useState("");
   const [expirationDate, setExpirationDate] = useState(null);
   const [lastUseTime, setLastUseTime] = useState(null);
@@ -261,6 +262,10 @@ const AccessTokenDetails = () => {
       toast.info("No changes to save");
       return;
     }
+    if (hasNameChange && tokenName.length > MAX_TOKEN_NAME_LENGTH) {
+      toast.error(`Access token name must be at most ${MAX_TOKEN_NAME_LENGTH} characters.`);
+      return;
+    }
 
     setLoading(true);
     try {
@@ -360,21 +365,26 @@ const AccessTokenDetails = () => {
               General Settings
             </div>
 
-            <div className="flex flex-row mt-1 my-4">
+            <div className="flex flex-row mt-1 my-4 items-center">
               <div className="flex flex-col w-1/4 md:w-1/6">
                 <div className="text-sm md:text-md text-gray1 font-semibold mt-2">
                   Token Name
                 </div>
               </div>
-              <TextBox
-                value={tokenName}
-                onChange={(e) => setTokenName(e.target.value)}
-                type="text"
-                placeholder="Token name"
-                maxLength={50}
-                textAlign="left"
-                width="w-2/3 md:w-1/3"
-              />
+              <div className="flex flex-col flex-1">
+                <TextBox
+                  value={tokenName}
+                  onChange={(e) => {
+                    if (e.target.value.length <= MAX_TOKEN_NAME_LENGTH) setTokenName(e.target.value);
+                  }}
+                  type="text"
+                  placeholder="Token name"
+                  maxLength={MAX_TOKEN_NAME_LENGTH}
+                  textAlign="left"
+                  width="w-2/3 md:w-1/3"
+                />
+                <span className="text-gray1 text-xs mt-1">{tokenName.length}/{MAX_TOKEN_NAME_LENGTH} characters</span>
+              </div>
             </div>
 
             <div className="flex flex-row mt-4 my-4">

--- a/src/pages/GenerateNewToken.js
+++ b/src/pages/GenerateNewToken.js
@@ -132,10 +132,11 @@ const GenerateNewToken = () => {
         }
     };
 
+    const MAX_TOKEN_NAME_LENGTH = 30;
     const handleAccessTokenNameChange = (e) => {
-        const words = e.target.value.split(/\s+/).filter(word => word.length > 0);
-        if (words.length <= 30) {
-            setAccessTokenName(e.target.value);
+        const value = e.target.value;
+        if (value.length <= MAX_TOKEN_NAME_LENGTH) {
+            setAccessTokenName(value);
         }
     };
 
@@ -200,7 +201,11 @@ const GenerateNewToken = () => {
 
     const handleGenerateToken = async () => {
         if (!accessTokenName.trim()) {
-            toast.error('access token name is required');
+            toast.error('Access token name is required');
+            return;
+        }
+        if (accessTokenName.length > MAX_TOKEN_NAME_LENGTH) {
+            toast.error(`Access token name must be at most ${MAX_TOKEN_NAME_LENGTH} characters.`);
             return;
         }
 
@@ -277,7 +282,7 @@ const GenerateNewToken = () => {
     };
 
     // Count words in access token name
-    const wordCount = accessTokenName.split(/\s+/).filter(word => word.length > 0).length;
+    const charCount = accessTokenName.length;
 
     return (
         <SidebarLayout active={6} breadcrumb={`${localStorage.getItem('project')} > Access Tokens > Generate New`}>
@@ -315,7 +320,7 @@ const GenerateNewToken = () => {
                                 className="w-full bg-black3 text-sm border border-gray2 border-opacity-30 rounded-lg px-4 py-2 mt-1 text-gray2 resize-none focus:outline-none focus:border-green"
                             />
                             <p className="text-gray1 text-xs mt-1">
-                                {wordCount}/30 words
+                                {charCount}/{MAX_TOKEN_NAME_LENGTH} characters
                             </p>
                         </div>
                         {/* Expiration */}


### PR DESCRIPTION
This pull request introduces a consistent character limit for access token names across both the token generation and details pages, improving user experience and validation. The changes ensure that token names cannot exceed 30 characters, provide immediate feedback in the UI, and update error messages accordingly.

1. **Access Token Name Length Enforcement and UI Improvements**

2.. **Added a constant `MAX_TOKEN_NAME_LENGTH` set to 30 in both `AccessTokenDetails.js` and `GenerateNewToken.js`** 